### PR TITLE
remove player from event arguments + ensure driver is current player

### DIFF
--- a/client/main.ts
+++ b/client/main.ts
@@ -17,10 +17,12 @@ alt.on("gameEntityCreate", (entity: alt.Entity) => {
 });
 
 alt.on("keydown", (key: alt.KeyCode) => {
-	if (alt.Player.local.vehicle === null)
+	const vehicle = alt.Player.local.vehicle;
+	if (vehicle === null)
 		return; // Don't need to execute nothing if you aren't in a vehicle.
 
-	const vehicle = alt.Player.local.vehicle;
+	if (vehicle.netOwner !== alt.Player.local)
+		return;
 
 	if (key === KEY_J) {
 		// Indicate left

--- a/client/main.ts
+++ b/client/main.ts
@@ -36,7 +36,7 @@ alt.on("keydown", (key: alt.KeyCode) => {
 		vehicle.indicator.left = !vehicle.indicator.left;
 		native.setVehicleIndicatorLights(vehicle, 1, vehicle.indicator.left);
 
-		alt.emitServer("indicators:SetIndicators", alt.Player.local, vehicle, vehicle.indicator.left, vehicle.indicator.right);
+		alt.emitServer("indicators:SetIndicators", vehicle, vehicle.indicator.left, vehicle.indicator.right);
 	} else if (key === KEY_L) {
 		// Indicate right
 
@@ -51,7 +51,7 @@ alt.on("keydown", (key: alt.KeyCode) => {
 		vehicle.indicator.right = !vehicle.indicator.right;
 		native.setVehicleIndicatorLights(vehicle, 0, vehicle.indicator.right);
 
-		alt.emitServer("indicators:SetIndicators", alt.Player.local, vehicle, vehicle.indicator.left, vehicle.indicator.right);
+		alt.emitServer("indicators:SetIndicators", vehicle, vehicle.indicator.left, vehicle.indicator.right);
 	} else if (key === KEY_K) {
 		// Hazard lights.
 		// Priority over other kinds of lights.
@@ -66,6 +66,8 @@ alt.on("keydown", (key: alt.KeyCode) => {
 
 		native.setVehicleIndicatorLights(vehicle, 0, vehicle.indicator.left);
 		native.setVehicleIndicatorLights(vehicle, 1, vehicle.indicator.right);
+
+		alt.emitServer("indicators:SetIndicators", vehicle, vehicle.indicator.left, vehicle.indicator.right);
 	}
 });
 

--- a/server/main.ts
+++ b/server/main.ts
@@ -2,6 +2,8 @@ import alt from "alt-server";
 import chalk from "chalk";
 
 alt.onClient("indicators:SetIndicator", (player: alt.Player, vehicle: alt.Vehicle, left: boolean, right: boolean) => {
+	if (vehicle.driver.id !== player.id) return;
+
 	vehicle.setStreamSyncedMeta("leftIndicator", left);
 	vehicle.setStreamSyncedMeta("rightIndicator", right);
 });


### PR DESCRIPTION
Player is not needed when sending event to server, which resulted in the arguments shifted across by one, and the vehicle got attached to the metadata of the player. Player is also checked for as the driver on the client (via `netOwner`) and on the server (via `driver`) which ensures the indicators cannot be modified by a passenger.

> '`netOwner`' is determined by the driver, regardless of who sits in any passenger seat. This behaviour can be seen when a player shifts from a front passenger seat to the driver seat or exiting and entering a vehicle where it will appear to blink / flash before starting the vehicle engine.

https://docs.altv.mp/js/api/alt-client.html#_altmp_altv_types_alt_client_emitServer
https://docs.altv.mp/js/api/alt-server.html#_altmp_altv_types_alt_server_onClient
> `...args` is a direct mapping of those provided from the client event call, `player` is provided as the origin of said event.